### PR TITLE
Set return code 1 if any segment fails. Fixes #9

### DIFF
--- a/bin/copper
+++ b/bin/copper
@@ -73,7 +73,7 @@ module Copper
 			content.split('---').each_with_index do |part, idx|
 				puts "Validating part #{idx}"
 				file = YAML::load(part)
-				failed = validate(rules, file, content_file)
+				failed = true if validate(rules, file, content_file)
 			end
 
 			exit(1) if failed


### PR DESCRIPTION
This change will preserve the "failed" status internally so that any template failure results in a return code of `1`. Previously, the `failed` variable was overwritten on each template run, so the return code only reflected the final template during validation.