### PR TITLE
Fix type conversion error when no validation error is present.

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -256,7 +256,17 @@ func fetchResult(vm *otto.Otto) ([]map[string]interface{}, error) {
 		return nil, err
 	}
 
-	result := jsArray.([]map[string]interface{})
+	var result []map[string]interface{}
+
+	switch v := jsArray.(type) {
+	default:
+		log.Fatalf("unexpected type: %T", v)
+	case []interface{}:
+		result = make([]map[string]interface{}, 0)
+	case []map[string]interface{}:
+		result = jsArray.([]map[string]interface{})
+	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
If validation succeeds, you still get an error like "interface {} is []interface {}, not []map[string]interface {}", to fix this I did a type check on the variable jsArray and returned the expected result based on that.